### PR TITLE
Made Changes to app.py

### DIFF
--- a/functions/create_and_email_accept_reject_links/app.py
+++ b/functions/create_and_email_accept_reject_links/app.py
@@ -19,8 +19,8 @@ def lambda_handler(event, context):
     api_id=os.environ['HttpApiID']
     sns_arn=os.environ['SNSArn']
     task_token= event['token']
-    url_template_sucess = f'https://{api_id}.execute-api.us-east-1.amazonaws.com/v1/respond?type=success&{urllib.parse.urlencode({"token":{task_token}})}'
-    url_template_fail = f'https://{api_id}.execute-api.us-east-1.amazonaws.com/v1/respond?type=fail&{urllib.parse.urlencode({"token":{task_token}})}'
+    url_template_sucess = f'https://{api_id}.execute-api.us-east-1.amazonaws.com/v1/respond?type=success&{urllib.parse.urlencode({"token":task_token})}'
+    url_template_fail = f'https://{api_id}.execute-api.us-east-1.amazonaws.com/v1/respond?type=fail&{urllib.parse.urlencode({"token":task_token})}'
     #encoded_str=urllib.parse.urlencode(url_template_sucess)
     msg_body = f'''
         Please find the transformed data in S3 bucket {s3_batch_output}, based on your findings approve or reject enpoint request</title> <body> Please find the transformed data in S3 bucket s3://mlops-cicd/output, based on your findings approve or reject enpoint request


### PR DESCRIPTION
*Issue #, if available:* When the user clicks on accept or reject mail sent by the Lambda function, API Gateway returns Internal Server error as the task token was not valid for SendTaskSuccess API call

*Description of changes:* Noticed that the Lambda function code app.py includes {} around query string token and this will cause issue while fetching the token in other Lambda function that respond to API Gateway requests and call SendTaskSuccess API call. Removed the {} in query string parameter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
